### PR TITLE
Migrate to kt-paperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Paperclip Transcoder
 
-Audio/Video Transcoder for Paperclip using FFMPEG/Avconv.
+Audio/Video Transcoder for kt-paperclip using FFMPEG/Avconv.
 
 This is a replacement for ( https://github.com/owahab/paperclip-ffmpeg ).
 
@@ -16,7 +16,7 @@ This is a replacement for ( https://github.com/owahab/paperclip-ffmpeg ).
 
 Add this line to your application's Gemfile:
 
-    gem 'paperclip-av-transcoder'
+    gem 'kt-paperclip-av-transcoder'
 
 And then execute:
 
@@ -24,7 +24,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install paperclip-av-transcoder
+    $ gem install kt-paperclip-av-transcoder
 
 ## Usage
 
@@ -45,7 +45,7 @@ This will produce:
 
 ### Meta Data
 
-Then paperclip-av-transcoder can optionally add uploaded file meta data to a database column for `<your_attachment>_meta`.
+Then kt-paperclip-av-transcoder can optionally add uploaded file meta data to a database column for `<your_attachment>_meta`.
 
 Example: Given a model called `User` with an attachment field named `:avatar`, create a new migration to add an `avatar_meta` column to the `users` table.
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a replacement for ( https://github.com/owahab/paperclip-ffmpeg ).
 
 Add this line to your application's Gemfile:
 
-    gem 'paperclip-av-transcoder'
+    gem 'kt-paperclip-av-transcoder'
 
 And then execute:
 
@@ -28,7 +28,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install paperclip-av-transcoder
+    $ gem install kt-paperclip-av-transcoder
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Notice
+
+This is a fork to make the [paperclip-av-transcoder](https://github.com/ruby-av/paperclip-av-transcoder) gem compatible with [kt-paperclip](https://github.com/kreeti/kt-paperclip).
+
 # Paperclip Transcoder
 
 Audio/Video Transcoder for kt-paperclip using FFMPEG/Avconv.
@@ -16,7 +20,7 @@ This is a replacement for ( https://github.com/owahab/paperclip-ffmpeg ).
 
 Add this line to your application's Gemfile:
 
-    gem 'kt-paperclip-av-transcoder'
+    gem 'paperclip-av-transcoder'
 
 And then execute:
 
@@ -24,7 +28,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install kt-paperclip-av-transcoder
+    $ gem install paperclip-av-transcoder
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a replacement for ( https://github.com/owahab/paperclip-ffmpeg ).
 
 Add this line to your application's Gemfile:
 
-    gem 'kt-paperclip-av-transcoder'
+    gem 'paperclip-av-transcoder'
 
 And then execute:
 
@@ -28,7 +28,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install kt-paperclip-av-transcoder
+    $ gem install paperclip-av-transcoder
 
 ## Usage
 

--- a/paperclip-av-transcoder.gemspec
+++ b/paperclip-av-transcoder.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "coveralls"
 
-  spec.add_dependency "kt-paperclip", "~> 7"
+  spec.add_dependency "kt-paperclip", ">=2.5.2"
   spec.add_dependency "av", "~> 0.9.0"
 end

--- a/paperclip-av-transcoder.gemspec
+++ b/paperclip-av-transcoder.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.0.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rails", ">= 4.0.0"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "coveralls"
 
-  spec.add_dependency "paperclip", ">=2.5.2"
+  spec.add_dependency "kt-paperclip", "~> 7"
   spec.add_dependency "av", "~> 0.9.0"
 end

--- a/paperclip-av-transcoder.gemspec
+++ b/paperclip-av-transcoder.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'paperclip/av/transcoder/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "paperclip-av-transcoder"
+  spec.name          = "kt-paperclip-av-transcoder"
   spec.version       = Paperclip::Av::Transcoder::VERSION
-  spec.authors       = ["Omar Abdel-Wahab"]
+  spec.authors       = ["Omar Abdel-Wahab", "André Andrade"]
   spec.email         = ["owahab@gmail.com"]
-  spec.summary       = %q{Audio/Video Transcoder for Paperclip using FFMPEG/Avconv}
-  spec.description   = %q{Audio/Video Transcoder for Paperclip using FFMPEG/Avconv}
-  spec.homepage      = "https://github.com/ruby-av/paperclip-av-transcoder"
+  spec.summary       = %q{Audio/Video Transcoder for kt-paperclip using FFMPEG/Avconv}
+  spec.description   = %q{Audio/Video Transcoder for kt-paperclip using FFMPEG/Avconv}
+  spec.homepage      = "https://github.com/hole19/kt-paperclip-av-transcoder"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/paperclip-av-transcoder.gemspec
+++ b/paperclip-av-transcoder.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'paperclip/av/transcoder/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "kt-paperclip-av-transcoder"
+  spec.name          = "paperclip-av-transcoder"
   spec.version       = Paperclip::Av::Transcoder::VERSION
-  spec.authors       = ["Omar Abdel-Wahab", "André Andrade"]
+  spec.authors       = ["Omar Abdel-Wahab"]
   spec.email         = ["owahab@gmail.com"]
   spec.summary       = %q{Audio/Video Transcoder for kt-paperclip using FFMPEG/Avconv}
   spec.description   = %q{Audio/Video Transcoder for kt-paperclip using FFMPEG/Avconv}


### PR DESCRIPTION
Migrates the dependency from [paperclip](https://github.com/thoughtbot/paperclip) to [kt-paperclip](https://github.com/kreeti/kt-paperclip).